### PR TITLE
Fix golang.sh and openshift.sh

### DIFF
--- a/.provisioners/_scripts/golang.sh
+++ b/.provisioners/_scripts/golang.sh
@@ -1,4 +1,6 @@
-#!/usr/bin/env zsh
+#!/usr/bin/env bash
+
+set -x
 
 version="$(curl -L 'https://golang.org/VERSION?m=text')"
 
@@ -7,7 +9,7 @@ rm -rf /usr/local/go && tar -C /usr/local -xzf ${version}.linux-amd64.tar.gz
 rm -f ${version}.linux-amd64.tar.gz
 
 CONFIG="/home/vagrant/.zshrc.d/golang.zsh"
-mkdir -p $(basename $CONFIG)
+mkdir -p $(dirname $CONFIG)
 rm -f $CONFIG
 echo "path=(/usr/local/go/bin \$path)" > $CONFIG
 echo "export PATH" >> $CONFIG

--- a/.provisioners/_scripts/openshift.sh
+++ b/.provisioners/_scripts/openshift.sh
@@ -1,4 +1,6 @@
-#!/usr/bin/env zsh
+#!/usr/bin/env bash
+
+set -x
 
 VERSION=${1:-latest}
 URL="${URL:-https://mirror.openshift.com/pub/openshift-v4/clients/ocp}"
@@ -11,7 +13,7 @@ wget "${URL}/${VERSION}/openshift-install-linux-${VERSION}.tar.gz" && tar -xzvf 
 rm openshift-install-linux-${VERSION}.tar.gz openshift-client-linux-${VERSION}.tar.gz
 
 CONFIG="/home/vagrant/.zshrc.d/openshift.zsh"
-mkdir -p $(basename $CONFIG)
+mkdir -p $(dirname $CONFIG)
 rm -f $CONFIG
 echo "path=($DIR \$path)" > $CONFIG
 echo "export PATH" >> $CONFIG

--- a/.provisioners/system/fedora/packages
+++ b/.provisioners/system/fedora/packages
@@ -1,4 +1,4 @@
-PKGS+=(golang google-cloud-sdk)
+PKGS+=(git google-cloud-sdk)
 PKG_INSTALL="dnf install -y --nogpgcheck"
 PKG_UPGRADE="dnf upgrade -y --nogpgcheck --exclude=kernel*"
 REPO_INSTALL="dnf config-manager --add-repo"


### PR DESCRIPTION
 ```
    devmaster: /vagrant/.provisioners/provision.sh: line 35: /vagrant/.provisioners/system/common/golang.zsh: Is a directory
    devmaster: error: Failed dependencies:
    devmaster:  git is needed by gh-0:2.6.0-1.x86_64
...
    devmaster: + rm -f go1.18.linux-amd64.tar.gz
    devmaster: + CONFIG=/home/vagrant/.zshrc.d/golang.zsh
    devmaster: ++ basename /home/vagrant/.zshrc.d/golang.zsh
    devmaster: + mkdir -p golang.zsh
    devmaster: + rm -f /home/vagrant/.zshrc.d/golang.zsh
    devmaster: + echo 'path=(/usr/local/go/bin $path)'
    devmaster: /vagrant/.provisioners/system/common/01-golang.sh: line 14: /home/vagrant/.zshrc.d/golang.zsh: No such file or directory
...
    devmaster: + CONFIG=/home/vagrant/.zshrc.d/openshift.zsh
    devmaster: ++ basename /home/vagrant/.zshrc.d/openshift.zsh
    devmaster: + mkdir -p openshift.zsh
    devmaster: + rm -f /home/vagrant/.zshrc.d/openshift.zsh
    devmaster: + echo 'path=(/home/vagrant/src/openshift/installer/latest $path)'
    devmaster: /vagrant/.provisioners/user/common/04-openshift.sh: line 18: /home/vagrant/.zshrc.d/openshift.zsh: No such file or directory
```

Signed-off-by: Flavio Fernandes <flaviof@redhat.com>